### PR TITLE
feat: グローバルホットキー機能と自動コピー機能を追加

### DIFF
--- a/electron/hotkeyManager.cjs
+++ b/electron/hotkeyManager.cjs
@@ -1,0 +1,59 @@
+const { globalShortcut } = require('electron');
+
+class HotkeyManager {
+  constructor() {
+    this.hotkey = process.platform === 'darwin' ? 'Cmd+Shift+G' : 'Ctrl+Shift+G';
+    this.isRecording = false;
+    this.mainWindow = null;
+  }
+
+  // メインウィンドウの参照を設定
+  setMainWindow(mainWindow) {
+    this.mainWindow = mainWindow;
+  }
+
+  // 録音トグル機能を初期化
+  initialize() {
+    const toggleRecording = () => {
+      // レンダラープロセスに録音トグルを通知
+      if (this.mainWindow && !this.mainWindow.isDestroyed()) {
+        this.mainWindow.webContents.send('toggle-recording-hotkey');
+        console.log('録音トグル: ホットキー押下');
+      }
+    };
+
+    // ホットキーを登録
+    try {
+      const success = globalShortcut.register(this.hotkey, toggleRecording);
+      
+      if (success) {
+        console.log(`ホットキー登録成功: ${this.hotkey}`);
+        return true;
+      } else {
+        console.error(`ホットキー登録失敗: ${this.hotkey}`);
+        return false;
+      }
+    } catch (error) {
+      console.error('ホットキー登録エラー:', error);
+      return false;
+    }
+  }
+
+  // ホットキーを解除
+  unregister() {
+    globalShortcut.unregister(this.hotkey);
+    console.log(`ホットキー解除: ${this.hotkey}`);
+  }
+
+  // すべてのホットキーを解除
+  unregisterAll() {
+    globalShortcut.unregisterAll();
+  }
+
+  // 現在のホットキーを取得
+  getCurrentHotkey() {
+    return this.hotkey;
+  }
+}
+
+module.exports = HotkeyManager;

--- a/electron/hotkeyManager.cjs
+++ b/electron/hotkeyManager.cjs
@@ -3,7 +3,6 @@ const { globalShortcut } = require('electron');
 class HotkeyManager {
   constructor() {
     this.hotkey = process.platform === 'darwin' ? 'Cmd+Shift+G' : 'Ctrl+Shift+G';
-    this.isRecording = false;
     this.mainWindow = null;
   }
 

--- a/electron/hotkeyManager.cjs
+++ b/electron/hotkeyManager.cjs
@@ -17,7 +17,7 @@ class HotkeyManager {
       // レンダラープロセスに録音トグルを通知
       if (this.mainWindow && !this.mainWindow.isDestroyed()) {
         this.mainWindow.webContents.send('toggle-recording-hotkey');
-        console.log('録音トグル: ホットキー押下');
+        console.log('録音トグルリクエストを送信');
       }
     };
 
@@ -29,7 +29,7 @@ class HotkeyManager {
         console.log(`ホットキー登録成功: ${this.hotkey}`);
         return true;
       } else {
-        console.error(`ホットキー登録失敗: ${this.hotkey}`);
+        console.error(`ホットキー登録失敗: ${this.hotkey} - 他のアプリケーションで既に使用されている可能性があります`);
         return false;
       }
     } catch (error) {

--- a/electron/hotkeyManager.cjs
+++ b/electron/hotkeyManager.cjs
@@ -23,6 +23,10 @@ class HotkeyManager {
 
     // ホットキーを登録
     try {
+      if (globalShortcut.isRegistered(this.hotkey)) {
+        console.log(`ホットキーは既に登録されています: ${this.hotkey}`);
+        return true;
+      }
       const success = globalShortcut.register(this.hotkey, toggleRecording);
       
       if (success) {

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,9 +1,11 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, clipboard } = require('electron');
 const path = require('path');
 const OpenAIService = require('./openai-service.cjs');
+const HotkeyManager = require('./hotkeyManager.cjs');
 
 let mainWindow = null;
 let openAIService = null;
+let hotkeyManager = null;
 
 function createWindow() {
   mainWindow = new BrowserWindow({
@@ -56,16 +58,33 @@ function setupIPCHandlers() {
       return { success: false, error: error.message };
     }
   });
+  
+  // クリップボードに書き込み
+  ipcMain.handle('write-to-clipboard', async (event, text) => {
+    try {
+      clipboard.writeText(text);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error.message };
+    }
+  });
 }
 
 app.whenReady().then(() => {
   // OpenAIサービスを初期化
   openAIService = new OpenAIService();
   
+  // ホットキーマネージャーを初期化
+  hotkeyManager = new HotkeyManager();
+  
   // IPC ハンドラーを設定
   setupIPCHandlers();
   
   createWindow();
+  
+  // メインウィンドウの参照を設定してホットキーを初期化
+  hotkeyManager.setMainWindow(mainWindow);
+  hotkeyManager.initialize();
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
@@ -77,5 +96,12 @@ app.whenReady().then(() => {
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();
+  }
+});
+
+// アプリ終了時にホットキーを解除
+app.on('will-quit', () => {
+  if (hotkeyManager) {
+    hotkeyManager.unregisterAll();
   }
 });

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -68,6 +68,11 @@ function setupIPCHandlers() {
       return { success: false, error: error.message };
     }
   });
+  
+  // 現在のホットキーを取得
+  ipcMain.handle('get-current-hotkey', async () => {
+    return hotkeyManager.getCurrentHotkey();
+  });
 }
 
 app.whenReady().then(() => {

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -24,12 +24,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
   
   // ホットキーイベントのリスナー
   onHotkeyToggle: (callback) => {
-    ipcRenderer.on('toggle-recording-hotkey', callback);
+    const wrappedCallback = () => callback();
+    ipcRenderer.on('toggle-recording-hotkey', wrappedCallback);
+    // コールバックを返して後で削除できるようにする
+    return wrappedCallback;
   },
   
   // リスナーの削除
-  removeHotkeyListener: () => {
-    ipcRenderer.removeAllListeners('toggle-recording-hotkey');
+  removeHotkeyListener: (callback) => {
+    if (callback) {
+      ipcRenderer.removeListener('toggle-recording-hotkey', callback);
+    }
   },
   
   // 現在のホットキーを取得

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -16,9 +16,22 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
   },
   onMessage: (channel, func) => {
-    const validChannels = ['fromMain'];
+    const validChannels = ['fromMain', 'toggle-recording-hotkey'];
     if (validChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => func(...args));
     }
   },
+  
+  // ホットキーイベントのリスナー
+  onHotkeyToggle: (callback) => {
+    ipcRenderer.on('toggle-recording-hotkey', callback);
+  },
+  
+  // リスナーの削除
+  removeHotkeyListener: () => {
+    ipcRenderer.removeAllListeners('toggle-recording-hotkey');
+  },
+  
+  // クリップボードに書き込み
+  writeToClipboard: (text) => ipcRenderer.invoke('write-to-clipboard', text),
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -32,6 +32,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.removeAllListeners('toggle-recording-hotkey');
   },
   
+  // 現在のホットキーを取得
+  getCurrentHotkey: () => ipcRenderer.invoke('get-current-hotkey'),
+  
   // クリップボードに書き込み
   writeToClipboard: (text) => ipcRenderer.invoke('write-to-clipboard', text),
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,9 +17,18 @@ function App() {
   const [isProcessing, setIsProcessing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [platformHotkey, setPlatformHotkey] = useState('');
   
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const audioChunksRef = useRef<Blob[]>([]);
+
+  // プラットフォームに応じたホットキーを設定
+  useEffect(() => {
+    // Electronから現在のプラットフォームのホットキーを取得
+    window.electronAPI.getCurrentHotkey().then((hotkey: string) => {
+      setPlatformHotkey(hotkey);
+    });
+  }, []);
 
   // ホットキーイベントのリスナーを設定
   useEffect(() => {
@@ -191,7 +200,7 @@ function App() {
           </Box>
           
           <Chip 
-            label="ホットキー: Ctrl+Shift+G" 
+            label={`ホットキー: ${platformHotkey || 'Ctrl+Shift+G'}`} 
             size="small" 
             sx={{ mb: 2 }}
           />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,32 +146,33 @@ function App() {
     });
   }, []);
 
+  // ホットキートグルのハンドラー
+  const handleHotkeyToggle = useCallback(() => {
+    console.log('ホットキー押下を検出');
+    // isRecordingの最新の値を使用するため、直接状態を更新
+    setIsRecording(prev => {
+      if (prev) {
+        // 録音停止
+        if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
+          mediaRecorderRef.current.stop();
+        }
+        return false;
+      } else {
+        // 録音開始
+        startRecording();
+        return true;
+      }
+    });
+  }, [startRecording]);
+
   // ホットキーイベントのリスナーを設定
   useEffect(() => {
-    const handleHotkeyToggle = () => {
-      console.log('ホットキー押下を検出');
-      // isRecordingの最新の値を使用するため、直接状態を更新
-      setIsRecording(prev => {
-        if (prev) {
-          // 録音停止
-          if (mediaRecorderRef.current && mediaRecorderRef.current.state !== 'inactive') {
-            mediaRecorderRef.current.stop();
-          }
-          return false;
-        } else {
-          // 録音開始
-          startRecording();
-          return true;
-        }
-      });
-    };
-
     const removeCallback = window.electronAPI.onHotkeyToggle(handleHotkeyToggle);
 
     return () => {
       window.electronAPI.removeHotkeyListener(removeCallback);
     };
-  }, [startRecording]); // startRecordingを依存配列に追加
+  }, [handleHotkeyToggle]);
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -28,6 +28,7 @@ interface ElectronAPI {
   // ホットキー関連
   onHotkeyToggle: (callback: () => void) => void;
   removeHotkeyListener: () => void;
+  getCurrentHotkey: () => Promise<string>;
   
   // クリップボード
   writeToClipboard: (text: string) => Promise<{ success: boolean; error?: string }>;

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -26,8 +26,8 @@ interface ElectronAPI {
   onMessage: (channel: string, func: (...args: any[]) => void) => void;
   
   // ホットキー関連
-  onHotkeyToggle: (callback: () => void) => void;
-  removeHotkeyListener: () => void;
+  onHotkeyToggle: (callback: () => void) => () => void;
+  removeHotkeyListener: (callback?: () => void) => void;
   getCurrentHotkey: () => Promise<string>;
   
   // クリップボード

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -24,6 +24,13 @@ interface ElectronAPI {
   // 既存のメッセージング
   sendMessage: (channel: string, data: any) => void;
   onMessage: (channel: string, func: (...args: any[]) => void) => void;
+  
+  // ホットキー関連
+  onHotkeyToggle: (callback: () => void) => void;
+  removeHotkeyListener: () => void;
+  
+  // クリップボード
+  writeToClipboard: (text: string) => Promise<{ success: boolean; error?: string }>;
 }
 
 interface Window {


### PR DESCRIPTION
## 概要
音声録音のためのグローバルホットキー機能と、文字起こし完了時の自動コピー機能を実装しました。

## 実装内容
### 1. グローバルホットキー機能
- **Ctrl+Shift+G**（macOSでは**Cmd+Shift+G**）で録音の開始/停止をトグル
- Electronの`globalShortcut` APIを使用して実装
- ホットキーマネージャークラスでホットキーの登録/解除を管理

### 2. 自動コピー機能
- 文字起こしが完了すると自動的にテキストをクリップボードにコピー
- 「コピーしました」のスナックバー通知を表示
- Electronのメインプロセス経由でクリップボード操作を実装（ブラウザのフォーカス問題を回避）

### 3. UI改善
- 現在のホットキーを表示するChipコンポーネントを追加
- ユーザーが設定されたホットキーを確認できるように

## 動作確認
1. アプリケーションを起動
2. **Ctrl+Shift+G**を押すと録音開始（マイクアイコンがパルスアニメーション）
3. もう一度**Ctrl+Shift+G**を押すと録音停止
4. 文字起こしが完了すると自動的にクリップボードにコピーされる
5. 「コピーしました」のスナックバーが表示される

## 技術的な詳細
- IPCを使用してレンダラープロセスとメインプロセス間で通信
- クリップボード操作の権限問題を回避するためメインプロセスで実行
- ホットキーのリスナーは一度だけ登録し、メモリリークを防止

🤖 Generated with [Claude Code](https://claude.ai/code)