### PR TITLE
feat: APIキー設定機能の改善

### DIFF
--- a/apikey.html
+++ b/apikey.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>API Key Settings</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        overflow: hidden;
+        background: transparent;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        width: 100%;
+        height: 100%;
+      }
+      body {
+        -webkit-app-region: no-drag;
+        user-select: none;
+      }
+      #app {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/apikey.tsx"></script>
+  </body>
+</html>

--- a/apikey.html
+++ b/apikey.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'">
     <title>API Key Settings</title>
     <style>
       html, body {

--- a/electron/floatingMain.cjs
+++ b/electron/floatingMain.cjs
@@ -92,10 +92,11 @@ function createToastWindow(text) {
   const CHARS_PER_LINE = 40;
   const LINE_HEIGHT = 22;
   const MIN_CONTENT_HEIGHT = 60;
+  const MAX_CONTENT_HEIGHT = 200; // 最大高さを制限
   const HEADER_PADDING = 80;
   
   const lines = Math.ceil(text.length / CHARS_PER_LINE);
-  const contentHeight = Math.max(MIN_CONTENT_HEIGHT, lines * LINE_HEIGHT);
+  const contentHeight = Math.min(MAX_CONTENT_HEIGHT, Math.max(MIN_CONTENT_HEIGHT, lines * LINE_HEIGHT));
   const windowHeight = contentHeight + HEADER_PADDING;
   
   // フローティングウィンドウの現在位置を取得
@@ -194,6 +195,8 @@ function createToastWindow(text) {
             font-size: 14px;
             word-break: break-word;
             line-height: 1.5;
+            max-height: 200px;
+            overflow-y: auto;
           }
           @keyframes fadeIn {
             from { opacity: 0; transform: translateY(20px); }
@@ -287,10 +290,22 @@ function createApiKeyWindow() {
     apiKeyWindow = null;
   });
 
-  // フォーカスが外れたら閉じる
+  // フォーカスが外れたら遅延して閉じる
+  let blurTimeout = null;
   apiKeyWindow.on('blur', () => {
-    if (apiKeyWindow && !apiKeyWindow.isDestroyed()) {
-      apiKeyWindow.close();
+    // 遅延を設けることで、ウィンドウ内の要素間のフォーカス移動で閉じないようにする
+    blurTimeout = setTimeout(() => {
+      if (apiKeyWindow && !apiKeyWindow.isDestroyed()) {
+        apiKeyWindow.close();
+      }
+    }, 100);
+  });
+  
+  apiKeyWindow.on('focus', () => {
+    // フォーカスが戻った場合はタイマーをクリア
+    if (blurTimeout) {
+      clearTimeout(blurTimeout);
+      blurTimeout = null;
     }
   });
 }

--- a/electron/floatingMain.cjs
+++ b/electron/floatingMain.cjs
@@ -7,6 +7,7 @@ let mainWindow = null;
 let floatingWindow = null;
 let toastWindow = null;
 let apiKeyWindow = null;
+let apiKeyBlurTimeout = null; // グローバルスコープに移動
 let tray = null;
 let openAIService = null;
 let hotkeyManager = null;
@@ -232,6 +233,12 @@ function createToastWindow(text) {
 
 // APIキー入力ウィンドウを作成
 function createApiKeyWindow() {
+  // 既存のタイマーをクリア
+  if (apiKeyBlurTimeout) {
+    clearTimeout(apiKeyBlurTimeout);
+    apiKeyBlurTimeout = null;
+  }
+  
   if (apiKeyWindow) {
     apiKeyWindow.focus();
     return;
@@ -288,13 +295,17 @@ function createApiKeyWindow() {
 
   apiKeyWindow.on('closed', () => {
     apiKeyWindow = null;
+    // ウィンドウが閉じられた時にタイマーもクリア
+    if (apiKeyBlurTimeout) {
+      clearTimeout(apiKeyBlurTimeout);
+      apiKeyBlurTimeout = null;
+    }
   });
 
   // フォーカスが外れたら遅延して閉じる
-  let blurTimeout = null;
   apiKeyWindow.on('blur', () => {
     // 遅延を設けることで、ウィンドウ内の要素間のフォーカス移動で閉じないようにする
-    blurTimeout = setTimeout(() => {
+    apiKeyBlurTimeout = setTimeout(() => {
       if (apiKeyWindow && !apiKeyWindow.isDestroyed()) {
         apiKeyWindow.close();
       }
@@ -303,9 +314,9 @@ function createApiKeyWindow() {
   
   apiKeyWindow.on('focus', () => {
     // フォーカスが戻った場合はタイマーをクリア
-    if (blurTimeout) {
-      clearTimeout(blurTimeout);
-      blurTimeout = null;
+    if (apiKeyBlurTimeout) {
+      clearTimeout(apiKeyBlurTimeout);
+      apiKeyBlurTimeout = null;
     }
   });
 }

--- a/electron/floatingMain.cjs
+++ b/electron/floatingMain.cjs
@@ -6,16 +6,17 @@ const HotkeyManager = require('./hotkeyManager.cjs');
 let mainWindow = null;
 let floatingWindow = null;
 let toastWindow = null;
+let apiKeyWindow = null;
 let tray = null;
 let openAIService = null;
 let hotkeyManager = null;
-let recordingHistory = [];
 
 // ウィンドウサイズ定数
 const WINDOW_SIZES = {
   FLOATING: { width: 80, height: 80 },
   TOAST: { width: 400, height: 120 },
-  MAIN: { width: 1000, height: 700 }
+  MAIN: { width: 1000, height: 700 },
+  APIKEY: { width: 350, height: 80 }
 };
 
 // 間隔・位置定数
@@ -87,6 +88,16 @@ function createFloatingWindow() {
 
 // トースト通知ウィンドウを作成
 function createToastWindow(text) {
+  // テキストの長さに基づいて高さを計算
+  const CHARS_PER_LINE = 40;
+  const LINE_HEIGHT = 22;
+  const MIN_CONTENT_HEIGHT = 60;
+  const HEADER_PADDING = 80;
+  
+  const lines = Math.ceil(text.length / CHARS_PER_LINE);
+  const contentHeight = Math.max(MIN_CONTENT_HEIGHT, lines * LINE_HEIGHT);
+  const windowHeight = contentHeight + HEADER_PADDING;
+  
   // フローティングウィンドウの現在位置を取得
   let toastX, toastY;
   let display;
@@ -122,7 +133,7 @@ function createToastWindow(text) {
     toastX = Math.max(display.bounds.x + SPACING.TOAST_OFFSET, 
                      Math.min(toastX, display.bounds.x + display.bounds.width - WINDOW_SIZES.TOAST.width - SPACING.TOAST_OFFSET));
     toastY = Math.max(display.bounds.y + SPACING.TOAST_OFFSET, 
-                     Math.min(toastY, display.bounds.y + display.bounds.height - WINDOW_SIZES.TOAST.height - SPACING.TOAST_OFFSET));
+                     Math.min(toastY, display.bounds.y + display.bounds.height - windowHeight - SPACING.TOAST_OFFSET));
     
   } else {
     // フローティングウィンドウがない場合はプライマリディスプレイの従来位置
@@ -133,7 +144,7 @@ function createToastWindow(text) {
 
   toastWindow = new BrowserWindow({
     width: WINDOW_SIZES.TOAST.width,
-    height: WINDOW_SIZES.TOAST.height,
+    height: windowHeight,
     x: toastX,
     y: toastY,
     frame: false,
@@ -167,6 +178,8 @@ function createToastWindow(text) {
             padding: 16px;
             box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
             animation: fadeIn 0.3s ease-out;
+            min-width: 200px;
+            max-width: 380px;
           }
           .success-header {
             display: flex;
@@ -180,9 +193,7 @@ function createToastWindow(text) {
             color: white;
             font-size: 14px;
             word-break: break-word;
-            max-height: 60px;
-            overflow: hidden;
-            text-overflow: ellipsis;
+            line-height: 1.5;
           }
           @keyframes fadeIn {
             from { opacity: 0; transform: translateY(20px); }
@@ -213,6 +224,74 @@ function createToastWindow(text) {
 
   toastWindow.on('closed', () => {
     toastWindow = null;
+  });
+}
+
+// APIキー入力ウィンドウを作成
+function createApiKeyWindow() {
+  if (apiKeyWindow) {
+    apiKeyWindow.focus();
+    return;
+  }
+
+  // フローティングウィンドウの位置を取得
+  const [floatingX, floatingY] = floatingWindow.getPosition();
+  const floatingBounds = floatingWindow.getBounds();
+  
+  // 現在のディスプレイを取得
+  const display = screen.getDisplayNearestPoint({ x: floatingX, y: floatingY });
+  
+  // フローティングボタンの右側に表示
+  let x = floatingX + floatingBounds.width + SPACING.TOAST_OFFSET;
+  let y = floatingY + (floatingBounds.height - WINDOW_SIZES.APIKEY.height) / 2;
+  
+  // 右側に入らない場合は左側に表示
+  if (x + WINDOW_SIZES.APIKEY.width > display.bounds.x + display.bounds.width) {
+    x = floatingX - WINDOW_SIZES.APIKEY.width - SPACING.TOAST_OFFSET;
+  }
+  
+  // 上下の境界チェック
+  if (y < display.bounds.y) {
+    y = display.bounds.y + SPACING.TOAST_OFFSET;
+  } else if (y + WINDOW_SIZES.APIKEY.height > display.bounds.y + display.bounds.height) {
+    y = display.bounds.y + display.bounds.height - WINDOW_SIZES.APIKEY.height - SPACING.TOAST_OFFSET;
+  }
+
+  apiKeyWindow = new BrowserWindow({
+    width: WINDOW_SIZES.APIKEY.width,
+    height: WINDOW_SIZES.APIKEY.height,
+    x: x,
+    y: y,
+    frame: false,
+    transparent: true,
+    alwaysOnTop: true,
+    resizable: false,
+    skipTaskbar: true,
+    backgroundColor: '#00000000',
+    hasShadow: true,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.cjs'),
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  // 開発環境の場合
+  if (process.env.NODE_ENV === 'development') {
+    apiKeyWindow.loadURL('http://localhost:5173/apikey.html');
+  } else {
+    apiKeyWindow.loadFile(path.join(__dirname, '../dist/apikey.html'));
+  }
+
+  apiKeyWindow.on('closed', () => {
+    apiKeyWindow = null;
+  });
+
+  // フォーカスが外れたら閉じる
+  apiKeyWindow.on('blur', () => {
+    if (apiKeyWindow && !apiKeyWindow.isDestroyed()) {
+      apiKeyWindow.close();
+    }
   });
 }
 
@@ -265,18 +344,7 @@ function updateTrayMenu() {
       },
     },
     {
-      label: '認識履歴',
-      submenu: recordingHistory.length > 0 
-        ? recordingHistory.slice(-10).reverse().map((item, index) => ({
-            label: `${index + 1}. ${item.text.substring(0, 30)}${item.text.length > 30 ? '...' : ''}`,
-            click: () => {
-              clipboard.writeText(item.text);
-            },
-          }))
-        : [{ label: '履歴なし', enabled: false }],
-    },
-    {
-      label: '設定',
+      label: 'API キー設定',
       click: () => {
         if (!mainWindow) {
           createMainWindow();
@@ -315,16 +383,6 @@ function setupIPCHandlers() {
   ipcMain.handle('transcribe-audio', async (_, audioBuffer, options) => {
     try {
       const result = await openAIService.transcribeAudio(audioBuffer, options);
-      
-      // 履歴に追加
-      if (result && result.text) {
-        recordingHistory.push({
-          text: result.text,
-          timestamp: new Date(),
-        });
-        updateTrayMenu();
-      }
-      
       return { success: true, data: result };
     } catch (error) {
       return { success: false, error: error.message };
@@ -353,7 +411,7 @@ function setupIPCHandlers() {
     }
   });
 
-  ipcMain.on('update-recording-state', (event, isRecording) => {
+  ipcMain.on('update-recording-state', (_, isRecording) => {
     // フローティングウィンドウのUIを更新
     if (floatingWindow) {
       floatingWindow.webContents.send('recording-state-changed', isRecording);
@@ -374,6 +432,11 @@ function setupIPCHandlers() {
       const currentPos = floatingWindow.getPosition();
       floatingWindow.setPosition(currentPos[0] + deltaX, currentPos[1] + deltaY);
     }
+  });
+  
+  // コンテキストメニューを表示
+  ipcMain.on('show-context-menu', () => {
+    createApiKeyWindow();
   });
 }
 

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -16,7 +16,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     }
   },
   onMessage: (channel, func) => {
-    const validChannels = ['fromMain', 'toggle-recording-hotkey'];
+    const validChannels = ['fromMain', 'toggle-recording-hotkey', 'open-settings'];
     if (validChannels.includes(channel)) {
       ipcRenderer.on(channel, (event, ...args) => func(...args));
     }
@@ -59,4 +59,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   
   // ウィンドウ移動用
   moveWindow: (deltaX, deltaY) => ipcRenderer.send('move-window', deltaX, deltaY),
+  
+  // コンテキストメニューを表示
+  showContextMenu: () => ipcRenderer.send('show-context-menu'),
 });

--- a/src/ApiKeyInput.tsx
+++ b/src/ApiKeyInput.tsx
@@ -95,11 +95,7 @@ function ApiKeyInput() {
         setSaved(true);
         setTimeout(() => {
           try {
-            try {
-        window.close();
-      } catch (e) {
-        console.error('ウィンドウを閉じる際にエラーが発生しました:', e);
-      }
+            window.close();
           } catch (e) {
             console.error('ウィンドウを閉じる際にエラーが発生しました:', e);
           }
@@ -116,7 +112,7 @@ function ApiKeyInput() {
     }
   };
 
-  const handleKeyPress = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       handleSave();
     } else if (e.key === 'Escape') {
@@ -150,7 +146,7 @@ function ApiKeyInput() {
           type={showApiKey ? 'text' : 'password'}
           value={apiKey}
           onChange={(e) => setApiKey(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           placeholder="OpenAI API Key (sk-...)"
           disabled={loading || saved}
           autoComplete="off"

--- a/src/ApiKeyInput.tsx
+++ b/src/ApiKeyInput.tsx
@@ -94,7 +94,15 @@ function ApiKeyInput() {
       if (result) {
         setSaved(true);
         setTimeout(() => {
-          window.close();
+          try {
+            try {
+        window.close();
+      } catch (e) {
+        console.error('ウィンドウを閉じる際にエラーが発生しました:', e);
+      }
+          } catch (e) {
+            console.error('ウィンドウを閉じる際にエラーが発生しました:', e);
+          }
         }, TIMERS.CLOSE_DELAY);
       } else {
         setError('保存に失敗しました');
@@ -112,7 +120,11 @@ function ApiKeyInput() {
     if (e.key === 'Enter') {
       handleSave();
     } else if (e.key === 'Escape') {
-      window.close();
+      try {
+        window.close();
+      } catch (e) {
+        console.error('ウィンドウを閉じる際にエラーが発生しました:', e);
+      }
     }
   };
 
@@ -141,6 +153,7 @@ function ApiKeyInput() {
           onKeyPress={handleKeyPress}
           placeholder="OpenAI API Key (sk-...)"
           disabled={loading || saved}
+          autoComplete="off"
           sx={{
             '& .MuiOutlinedInput-root': {
               backgroundColor: COLORS.INPUT_BACKGROUND,

--- a/src/ApiKeyInput.tsx
+++ b/src/ApiKeyInput.tsx
@@ -1,0 +1,226 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { ThemeProvider } from '@mui/material/styles';
+import { 
+  Box, 
+  TextField, 
+  IconButton, 
+  InputAdornment,
+  CircularProgress,
+  Tooltip
+} from '@mui/material';
+import { 
+  Visibility, 
+  VisibilityOff, 
+  Check as CheckIcon,
+  Close as CloseIcon 
+} from '@mui/icons-material';
+import theme from './theme';
+
+// 定数
+const TIMERS = {
+  FOCUS_DELAY: 100,
+  CLOSE_DELAY: 1000
+};
+
+const SIZES = {
+  ICON_SMALL: 20,
+  PADDING: 12,
+  FONT_SIZE: 14,
+  ERROR_FONT_SIZE: 12
+};
+
+const COLORS = {
+  BACKGROUND: 'rgba(0, 0, 0, 0.9)',
+  INPUT_BACKGROUND: 'rgba(255, 255, 255, 0.05)',
+  INPUT_BORDER: 'rgba(255, 255, 255, 0.2)',
+  INPUT_BORDER_HOVER: 'rgba(255, 255, 255, 0.3)',
+  INPUT_BORDER_FOCUS: '#2196F3',
+  PLACEHOLDER: 'rgba(255, 255, 255, 0.5)',
+  ICON: 'rgba(255, 255, 255, 0.7)',
+  ERROR: '#f44336',
+  SUCCESS: '#4caf50',
+  PRIMARY: '#2196F3',
+  DISABLED: 'rgba(255, 255, 255, 0.3)'
+};
+
+function ApiKeyInput() {
+  const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [validating, setValidating] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // 初期表示時にAPIキーを取得
+  useEffect(() => {
+    const loadApiKey = async () => {
+      try {
+        const key = await window.electronAPI.getApiKey();
+        if (key) {
+          setApiKey(key);
+        }
+      } catch (err) {
+        console.error('APIキーの読み込みエラー:', err);
+      }
+    };
+    loadApiKey();
+    
+    // フォーカスを設定
+    setTimeout(() => {
+      inputRef.current?.focus();
+    }, TIMERS.FOCUS_DELAY);
+  }, []);
+
+  const handleSave = async () => {
+    if (!apiKey || loading || validating) return;
+    
+    setError(null);
+    setValidating(true);
+    
+    try {
+      // APIキーを検証
+      const isValid = await window.electronAPI.testApiKey(apiKey);
+      
+      if (!isValid) {
+        setError('無効なAPIキーです');
+        setValidating(false);
+        return;
+      }
+      
+      // APIキーを保存
+      setLoading(true);
+      const result = await window.electronAPI.setApiKey(apiKey);
+      if (result) {
+        setSaved(true);
+        setTimeout(() => {
+          window.close();
+        }, TIMERS.CLOSE_DELAY);
+      } else {
+        setError('保存に失敗しました');
+      }
+    } catch (err) {
+      console.error('APIキーの保存エラー:', err);
+      setError('エラーが発生しました');
+    } finally {
+      setLoading(false);
+      setValidating(false);
+    }
+  };
+
+  const handleKeyPress = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      handleSave();
+    } else if (e.key === 'Escape') {
+      window.close();
+    }
+  };
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box
+        sx={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          backgroundColor: COLORS.BACKGROUND,
+          borderRadius: '8px',
+          padding: `${SIZES.PADDING}px`,
+          boxSizing: 'border-box',
+        }}
+      >
+        <TextField
+          inputRef={inputRef}
+          fullWidth
+          size="small"
+          type={showApiKey ? 'text' : 'password'}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          onKeyPress={handleKeyPress}
+          placeholder="OpenAI API Key (sk-...)"
+          disabled={loading || saved}
+          sx={{
+            '& .MuiOutlinedInput-root': {
+              backgroundColor: COLORS.INPUT_BACKGROUND,
+              color: 'white',
+              '& fieldset': {
+                borderColor: COLORS.INPUT_BORDER,
+              },
+              '&:hover fieldset': {
+                borderColor: COLORS.INPUT_BORDER_HOVER,
+              },
+              '&.Mui-focused fieldset': {
+                borderColor: COLORS.INPUT_BORDER_FOCUS,
+              },
+            },
+            '& .MuiInputBase-input': {
+              color: 'white',
+              fontSize: `${SIZES.FONT_SIZE}px`,
+              '&::placeholder': {
+                color: COLORS.PLACEHOLDER,
+              },
+            },
+          }}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton
+                  size="small"
+                  onClick={() => setShowApiKey(!showApiKey)}
+                  disabled={loading || saved}
+                  sx={{ color: COLORS.ICON }}
+                >
+                  {showApiKey ? <VisibilityOff fontSize="small" /> : <Visibility fontSize="small" />}
+                </IconButton>
+                {loading || validating ? (
+                  <CircularProgress size={SIZES.ICON_SMALL} sx={{ ml: 1 }} />
+                ) : saved ? (
+                  <CheckIcon sx={{ color: COLORS.SUCCESS, ml: 1 }} />
+                ) : (
+                  <Tooltip title="保存 (Enter)">
+                    <IconButton
+                      size="small"
+                      onClick={handleSave}
+                      sx={{ 
+                        color: apiKey ? COLORS.PRIMARY : COLORS.DISABLED,
+                        ml: 1
+                      }}
+                      disabled={!apiKey}
+                    >
+                      <CheckIcon fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                )}
+                <Tooltip title="キャンセル (Esc)">
+                  <IconButton
+                    size="small"
+                    onClick={() => window.close()}
+                    sx={{ color: COLORS.ICON, ml: 0.5 }}
+                  >
+                    <CloseIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </InputAdornment>
+            ),
+          }}
+        />
+        {error && (
+          <Box
+            sx={{
+              mt: 1,
+              color: COLORS.ERROR,
+              fontSize: `${SIZES.ERROR_FONT_SIZE}px`,
+              textAlign: 'center',
+            }}
+          >
+            {error}
+          </Box>
+        )}
+      </Box>
+    </ThemeProvider>
+  );
+}
+
+export default ApiKeyInput;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -178,6 +178,19 @@ function App() {
       window.electronAPI.removeHotkeyListener(removeCallback);
     };
   }, [handleHotkeyToggle]);
+  
+  // 設定ダイアログを開くイベントを受信
+  useEffect(() => {
+    const handleOpenSettings = () => {
+      setSettingsOpen(true);
+    };
+    
+    window.electronAPI.onMessage('open-settings', handleOpenSettings);
+    
+    return () => {
+      // クリーンアップ処理（必要に応じて）
+    };
+  }, []);
 
   return (
     <ThemeProvider theme={theme}>

--- a/src/FloatingApp.tsx
+++ b/src/FloatingApp.tsx
@@ -110,6 +110,12 @@ function FloatingApp() {
     }
   }, [isRecording, startRecording, stopRecording]);
 
+  // 右クリックメニューのハンドラー
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    // メインプロセスに右クリックイベントを通知
+    window.electronAPI.showContextMenu();
+  }, []);
+
   // ドラッグ処理
   const handleMouseDown = useCallback((e: React.MouseEvent) => {
     // ボタンのクリックエリア以外でドラッグを開始
@@ -174,7 +180,8 @@ function FloatingApp() {
       >
         <FloatingButton 
           isRecording={isRecording} 
-          onToggle={handleToggleRecording} 
+          onToggle={handleToggleRecording}
+          onContextMenu={handleContextMenu}
         />
       </div>
     </ThemeProvider>

--- a/src/apikey.tsx
+++ b/src/apikey.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ApiKeyInput from './ApiKeyInput';
+
+ReactDOM.createRoot(document.getElementById('app')!).render(
+  <React.StrictMode>
+    <ApiKeyInput />
+  </React.StrictMode>
+);

--- a/src/components/FloatingButton.tsx
+++ b/src/components/FloatingButton.tsx
@@ -49,16 +49,25 @@ const StyledIconButton = styled(IconButton)<{ isRecording: boolean }>(({ isRecor
 interface FloatingButtonProps {
   isRecording: boolean;
   onToggle: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
 }
 
-const FloatingButton: React.FC<FloatingButtonProps> = ({ isRecording, onToggle }) => {
+const FloatingButton: React.FC<FloatingButtonProps> = ({ isRecording, onToggle, onContextMenu }) => {
   const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation(); // 親のドラッグイベントを停止
     onToggle();
   };
 
+  const handleContextMenu = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (onContextMenu) {
+      onContextMenu(e);
+    }
+  };
+
   return (
-    <FloatingButtonContainer>
+    <FloatingButtonContainer onContextMenu={handleContextMenu}>
       <StyledIconButton isRecording={isRecording} onClick={handleClick}>
         <MicIcon sx={{ fontSize: 30 }} />
       </StyledIconButton>

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -43,6 +43,9 @@ interface ElectronAPI {
   
   // ウィンドウ移動
   moveWindow: (deltaX: number, deltaY: number) => void;
+  
+  // コンテキストメニューを表示
+  showContextMenu: () => void;
 }
 
 interface Window {

--- a/src/types/electron.d.ts
+++ b/src/types/electron.d.ts
@@ -1,9 +1,9 @@
 // Electron API の型定義
 interface ElectronAPI {
   // API キー管理
-  getApiKey: () => Promise<string>;
-  setApiKey: (apiKey: string) => Promise<boolean>;
-  testApiKey: (apiKey: string) => Promise<boolean>;
+  getApiKey: () => Promise<string>; // 保存されているAPIキーを取得
+  setApiKey: (apiKey: string) => Promise<boolean>; // APIキーを保存（成功時true）
+  testApiKey: (apiKey: string) => Promise<boolean>; // APIキーの有効性を検証（有効ならtrue）
   
   // 音声文字起こし
   transcribeAudio: (

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -11,6 +11,7 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'index.html'),
         floating: resolve(__dirname, 'floating.html'),
+        apikey: resolve(__dirname, 'apikey.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary
- フローティングボタンの右クリックで直接APIキーを設定できる機能を追加
- コンパクトな入力ウィンドウで素早くAPIキーを設定可能
- APIキーの有効性をリアルタイムで検証

## 主な変更点
- 右クリックで350x80pxのコンパクトな入力ウィンドウを表示
- APIキーの検証機能（OpenAI APIで有効性をチェック）
- エラーメッセージの表示（無効なAPIキー、保存失敗など）
- 成功時はチェックマークを表示して自動的にウィンドウを閉じる
- マジックナンバーの定数化（色、サイズ、タイマー値など）
- 不要な認識履歴機能を削除してUIをシンプル化
- トースト通知のサイズを内容に応じて自動調整

## Test plan
- [x] フローティングボタンを右クリックしてAPIキー入力ウィンドウが表示されることを確認
- [x] 無効なAPIキーを入力した際にエラーメッセージが表示されることを確認
- [x] 有効なAPIキーを入力した際にチェックマークが表示されることを確認
- [x] Escキーでウィンドウが閉じることを確認
- [x] Enterキーで保存処理が実行されることを確認
- [x] ウィンドウが画面境界を考慮して適切に配置されることを確認

## スクリーンショット
右クリックでフローティングボタンの横に小さなAPIキー入力フォームが表示されます。

🤖 Generated with [Claude Code](https://claude.ai/code)