### PR TITLE
fix: update version to 1.0.0 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "voice-commander",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.0.0",
   "description": "Voice Commander - A voice transcription app with floating widget",
   "author": "Masahiro Kubota",
   "type": "module",


### PR DESCRIPTION
## Summary
- package.jsonのバージョンを0.0.0から1.0.0に更新

## 背景
v1.0.0タグでのリリースビルドが失敗した原因:
- electron-builderがpackage.jsonのバージョン(0.0.0)を使用してリリースを作成しようとした
- GitHubの権限エラーが発生（403 Forbidden）

## 変更内容
- package.jsonのversionフィールドを1.0.0に更新

🤖 Generated with [Claude Code](https://claude.ai/code)